### PR TITLE
Parser now returns command object with arguments

### DIFF
--- a/Commands/Attack.java
+++ b/Commands/Attack.java
@@ -1,6 +1,7 @@
 package Commands;
 
 public class Attack extends BaseCommand {
+
     char identifier = 'a';
     String syntax = identifier + " (unit) [[unit]|[x]] [y]";
     String description = "Attack: Asks a (selected) unit to attack another.";

--- a/Commands/Attack.java
+++ b/Commands/Attack.java
@@ -7,6 +7,11 @@ public class Attack extends BaseCommand {
     String description = "Attack: Asks a (selected) unit to attack another.";
     byte minArguments = 0;
     byte maxArguments = 3;
+    String[] arguments;
+
+    public Attack(String[] args) {
+        arguments = args;
+    }
 
     @Override
     public char getIdentifier() {

--- a/Commands/BaseCommand.java
+++ b/Commands/BaseCommand.java
@@ -12,6 +12,7 @@ public abstract class BaseCommand {
     String tooFewArguments = ANSI_RED + "Too few arguments! Usage: " + syntax + ANSI_RESET;
     byte minArguments = 0;
     byte maxArguments = 1;
+    String[] arguments;
 
     public abstract char getIdentifier();
 

--- a/Commands/BaseCommand.java
+++ b/Commands/BaseCommand.java
@@ -1,6 +1,7 @@
 package Commands;
 
 public abstract class BaseCommand {
+
     final String ANSI_RESET = "\u001B[0m";
     final String ANSI_BLUE = "\u001B[34m";
     final String ANSI_RED = "\u001B[31m";

--- a/Commands/Help.java
+++ b/Commands/Help.java
@@ -7,6 +7,11 @@ public class Help extends BaseCommand {
     String description = "Help: List of commands.";
     byte minArguments = 0;
     byte maxArguments = 1;
+    String[] arguments;
+
+    public Help(String[] args) {
+        arguments = args;
+    }
 
     @Override
     public char getIdentifier() {

--- a/Commands/Help.java
+++ b/Commands/Help.java
@@ -1,6 +1,7 @@
 package Commands;
 
 public class Help extends BaseCommand {
+
     char identifier = 'h';
     String syntax = identifier + " [command]";
     String description = "Help: List of commands.";

--- a/Commands/Move.java
+++ b/Commands/Move.java
@@ -1,9 +1,12 @@
 package Commands;
 
 public class Move extends BaseCommand {
+
     char identifier = 'm';
     String syntax = identifier + " ([unit]|[x]) ([x]|[y]) [y]";
-    String description = "Move: Asks a (selected) unit to move to another unit's current square or a set of coordinates." + syntax;
+    String description =
+        "Move: Asks a (selected) unit to move to another unit's current square or a set of coordinates."
+            + syntax;
     byte minArguments = 0;
     byte maxArguments = 3;
 

--- a/Commands/Move.java
+++ b/Commands/Move.java
@@ -9,6 +9,11 @@ public class Move extends BaseCommand {
             + syntax;
     byte minArguments = 0;
     byte maxArguments = 3;
+    String[] arguments;
+
+    public Move(String[] args) {
+        arguments = args;
+    }
 
     @Override
     public char getIdentifier() {

--- a/Commands/Move.java
+++ b/Commands/Move.java
@@ -5,8 +5,8 @@ public class Move extends BaseCommand {
     char identifier = 'm';
     String syntax = identifier + " ([unit]|[x]) ([x]|[y]) [y]";
     String description =
-        "Move: Asks a (selected) unit to move to another unit's current square or a set of coordinates."
-            + syntax;
+      "Move: Asks a (selected) unit to move to another unit's current square or a set of coordinates."
+        + syntax;
     byte minArguments = 0;
     byte maxArguments = 3;
     String[] arguments;

--- a/Commands/Select.java
+++ b/Commands/Select.java
@@ -1,6 +1,7 @@
 package Commands;
 
 public class Select extends BaseCommand {
+
     char identifier = 's';
     String syntax = identifier + " ([unit]|[x]) [y]";
     String description = "Select: Selects and highlights a unit based on ID or square coordinates.";

--- a/Commands/Select.java
+++ b/Commands/Select.java
@@ -7,6 +7,11 @@ public class Select extends BaseCommand {
     String description = "Select: Selects and highlights a unit based on ID or square coordinates.";
     byte minArguments = 0;
     byte maxArguments = 2;
+    String[] arguments;
+
+    public Select(String[] args) {
+        arguments = args;
+    }
 
     @Override
     public char getIdentifier() {

--- a/Controller/GameController.java
+++ b/Controller/GameController.java
@@ -1,4 +1,5 @@
 package Controller;
+
 import Commands.BaseCommand;
 import View.GameViewInterface;
 import View.CommandLineInterface;
@@ -9,28 +10,31 @@ import java.util.Scanner;
 import java.util.Timer;
 
 public class GameController {
+
     GameViewInterface viewInterface;
     BaseBoard board;
 
     public GameController(int viewType, int boardType) {
-        switch(boardType) {
+        switch (boardType) {
             case 1:
                 board = new TestBoard();
                 break;
             default:
                 board = new Board();
         }
-        switch(viewType) {
+        switch (viewType) {
             default:
                 viewInterface = new CommandLineInterface();
         }
     }
+
     public void initialize() {
         Timer timer = new Timer();
         long oneSecond = 1000;
         RefreshMapTask task = new RefreshMapTask(viewInterface, board);
         timer.schedule(task, 0, oneSecond);
     }
+
     public void handleUserInput() {
         viewInterface.displayHelp();
         boolean consoleIsOpen = true;

--- a/Controller/Parser.java
+++ b/Controller/Parser.java
@@ -7,16 +7,18 @@ import java.util.ArrayList;
 public class Parser {
 
     public static BaseCommand getCommand(String input) {
-        String[] arguments = input.split("\\s+");
+        String[] inArguments = input.split("\\s+");
+        String[] outArguments = new String[inArguments.length - 1];
+        System.arraycopy(inArguments, 1, outArguments, 0, inArguments.length - 1);
 
         ArrayList<BaseCommand> commands = new ArrayList<>();
-        commands.add(new Attack());
-        commands.add(new Help());
-        commands.add(new Move());
-        commands.add(new Select());
+        commands.add(new Attack(outArguments));
+        commands.add(new Help(outArguments));
+        commands.add(new Move(outArguments));
+        commands.add(new Select(outArguments));
 
         try {
-            char commandID = arguments[0].charAt(0);
+            char commandID = inArguments[0].charAt(0);
             for (BaseCommand command : commands) {
                 if (commandID == command.getIdentifier()) {
                     return command;

--- a/Controller/Parser.java
+++ b/Controller/Parser.java
@@ -5,6 +5,7 @@ import Commands.*;
 import java.util.ArrayList;
 
 public class Parser {
+
     public static BaseCommand getCommand(String input) {
         String[] arguments = input.split("\\s+");
 
@@ -21,8 +22,7 @@ public class Parser {
                     return command;
                 }
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             return null;
         }
 

--- a/Controller/RefreshMapTask.java
+++ b/Controller/RefreshMapTask.java
@@ -1,15 +1,19 @@
 package Controller;
+
 import View.GameViewInterface;
 import Model.BaseBoard;
 import java.util.TimerTask;
 
 public class RefreshMapTask extends TimerTask {
+
     GameViewInterface viewInterface;
     BaseBoard board;
+
     public RefreshMapTask(GameViewInterface viewInterface, BaseBoard board) {
         this.viewInterface = viewInterface;
         this.board = board;
     }
+
     @Override
     public void run() {
         viewInterface.displayBoard(board);

--- a/Main.java
+++ b/Main.java
@@ -1,5 +1,7 @@
 import Controller.GameController;
+
 public class Main {
+
     public static void main(String[] args) {
         GameController controller = new GameController(-1, 1);
         controller.initialize();

--- a/Model/BaseBoard.java
+++ b/Model/BaseBoard.java
@@ -2,6 +2,6 @@ package Model;
 
 public abstract class BaseBoard {
 
-  @Override
-  public abstract String toString();
+    @Override
+    public abstract String toString();
 }

--- a/Model/Board.java
+++ b/Model/Board.java
@@ -1,21 +1,21 @@
 package Model;
 
 public class Board extends BaseBoard {
+
     public BoardCell[][] board;
     public int length;
     public int height;
 
     @Override
     // toString method used for printing the board
-    public String toString(){
+    public String toString() {
         StringBuilder builder = new StringBuilder();
-        for(BoardCell[] row : board) {
-            for(BoardCell column : row) {
+        for (BoardCell[] row : board) {
+            for (BoardCell column : row) {
                 // If there is no unit in cell
-                if(column.unit == null) {
-                    builder.append("0");
-                }
-                else {
+                if (column.unit == null) {
+                    builder.append(".");
+                } else {
                     builder.append(column.unit.getName());
                 }
                 builder.append(" ");
@@ -29,7 +29,7 @@ public class Board extends BaseBoard {
     public Path pathFinder(int rowStart, int columnStart, int rowEnd, int columnEnd) {
         Path path = new Path();
         Node pathNode = nextNode(rowStart, columnStart, rowEnd, columnEnd);
-        while(pathNode != null) {
+        while (pathNode != null) {
             path.addNode(pathNode.getRow(), pathNode.getColumn());
             pathNode = nextNode(pathNode.getRow(), pathNode.getColumn(), rowEnd, columnEnd);
         }
@@ -39,40 +39,40 @@ public class Board extends BaseBoard {
     // Gives the next closest node to the current that goes towards end node
     public Node nextNode(int rowCurrent, int columnCurrent, int rowEnd, int columnEnd) {
         // Diagonal path towards destination
-        if(rowCurrent != rowEnd && columnCurrent != columnEnd) {
+        if (rowCurrent != rowEnd && columnCurrent != columnEnd) {
             // Top left
-            if(rowCurrent > rowEnd && columnCurrent > columnEnd) {
+            if (rowCurrent > rowEnd && columnCurrent > columnEnd) {
                 return new Node(rowCurrent - 1, columnCurrent - 1);
             }
             // Top right
-            else if(rowCurrent > rowEnd && columnCurrent < columnEnd) {
+            else if (rowCurrent > rowEnd && columnCurrent < columnEnd) {
                 return new Node(rowCurrent - 1, columnCurrent + 1);
             }
             // Bottom left
-            else if(rowCurrent < rowEnd && columnCurrent > columnEnd) {
+            else if (rowCurrent < rowEnd && columnCurrent > columnEnd) {
                 return new Node(rowCurrent + 1, columnCurrent - 1);
             }
             // Bottom right
-            else if((rowCurrent < rowEnd && columnCurrent < columnEnd)) {
+            else if ((rowCurrent < rowEnd && columnCurrent < columnEnd)) {
                 return new Node(rowCurrent + 1, columnCurrent + 1);
             }
         }
         // Current is in the correct column
         // Up
-        else if(rowCurrent != rowEnd && rowEnd > rowCurrent) {
+        else if (rowCurrent != rowEnd && rowEnd > rowCurrent) {
             return new Node(rowCurrent + 1, columnCurrent);
         }
         // Down
-        else if(rowCurrent != rowEnd && rowEnd < rowCurrent) {
+        else if (rowCurrent != rowEnd && rowEnd < rowCurrent) {
             return new Node(rowCurrent - 1, columnCurrent);
         }
         // Current is in the correct row
         // Left
-        else if(columnCurrent != columnEnd && columnEnd < columnCurrent) {
+        else if (columnCurrent != columnEnd && columnEnd < columnCurrent) {
             return new Node(rowCurrent, columnCurrent - 1);
         }
         // Right
-        else if(columnCurrent != columnEnd && columnEnd > columnCurrent) {
+        else if (columnCurrent != columnEnd && columnEnd > columnCurrent) {
             return new Node(rowCurrent, columnCurrent + 1);
         }
         // Current equals End

--- a/Model/Board.java
+++ b/Model/Board.java
@@ -7,187 +7,190 @@ import java.util.HashMap;
 
 public class Board extends BaseBoard {
 
-  public BoardCell[][] board;
+    public BoardCell[][] board;
 
-  public Board(int row, int column) {
-    board = new BoardCell[row][column];
-    for (int i = 0; i < row; i++) {
-      for (int j = 0; j < column; j++) {
-        board[i][j] = new BoardCell(null);
-      }
-    }
-  }
-
-  public Board() {
-  }
-
-  @Override
-  // toString method used for printing the board
-  public String toString() {
-    StringBuilder builder = new StringBuilder();
-    for (BoardCell[] row : board) {
-      for (BoardCell column : row) {
-        // If there is no unit in cell
-        if (column.unit == null) {
-          builder.append("0");
-        } else {
-          builder.append(column.unit.getName());
+    public Board(int row, int column) {
+        board = new BoardCell[row][column];
+        for (int i = 0; i < row; i++) {
+            for (int j = 0; j < column; j++) {
+                board[i][j] = new BoardCell(null);
+            }
         }
-        builder.append(" ");
-      }
-      builder.append("\n");
     }
-    return builder.toString();
-  }
-  // Pathfinding.
-  public Path pathFinder(int rowStart, int columnStart, int rowEnd, int columnEnd,
+
+    public Board() {
+    }
+
+    @Override
+    // toString method used for printing the board
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for (BoardCell[] row : board) {
+            for (BoardCell column : row) {
+                // If there is no unit in cell
+                if (column.unit == null) {
+                    builder.append("0");
+                } else {
+                    builder.append(column.unit.getName());
+                }
+                builder.append(" ");
+            }
+            builder.append("\n");
+        }
+        return builder.toString();
+    }
+
+    // Pathfinding.
+    public Path pathFinder(int rowStart, int columnStart, int rowEnd, int columnEnd,
       BaseUnit.Team team, HashMap<Node, Boolean> exploredNodes) {
-    Path path = new Path();
-    if (rowStart < 0 || rowStart > board.length || columnStart < 0 || columnStart > board[0].length
-        || rowEnd < 0 || rowEnd > board.length || columnEnd > board[0].length) {
-      return null;
-    }
-    Node pathNode = nextNode(rowStart, columnStart, rowEnd, columnEnd);
-    while (pathNode != null) {
-      // The next location has a unit that is not on the same team
-      if (!checkTeam(board[pathNode.getRow()][pathNode.getColumn()], team)
-          || exploredNodes.containsKey(new Node(
-          pathNode.getRow(), pathNode.getColumn()))) {
-        Path nonEnemyPath;
-        if (path.getLength() == 0) {
-          nonEnemyPath = nonEnemyPath(rowStart, columnStart,
-              rowEnd, columnEnd, team, exploredNodes);
-        } else {
-          nonEnemyPath = nonEnemyPath(path.getLast().getRow(), path.getLast().getColumn(),
-              rowEnd, columnEnd, team, exploredNodes);
+        Path path = new Path();
+        if (rowStart < 0 || rowStart > board.length || columnStart < 0
+          || columnStart > board[0].length
+          || rowEnd < 0 || rowEnd > board.length || columnEnd > board[0].length) {
+            return null;
         }
-        if (nonEnemyPath != null) {
-          path.appendPath(nonEnemyPath);
-        } else {
-          path = null;
+        Node pathNode = nextNode(rowStart, columnStart, rowEnd, columnEnd);
+        while (pathNode != null) {
+            // The next location has a unit that is not on the same team
+            if (!checkTeam(board[pathNode.getRow()][pathNode.getColumn()], team)
+              || exploredNodes.containsKey(new Node(
+              pathNode.getRow(), pathNode.getColumn()))) {
+                Path nonEnemyPath;
+                if (path.getLength() == 0) {
+                    nonEnemyPath = nonEnemyPath(rowStart, columnStart,
+                      rowEnd, columnEnd, team, exploredNodes);
+                } else {
+                    nonEnemyPath = nonEnemyPath(path.getLast().getRow(), path.getLast().getColumn(),
+                      rowEnd, columnEnd, team, exploredNodes);
+                }
+                if (nonEnemyPath != null) {
+                    path.appendPath(nonEnemyPath);
+                } else {
+                    path = null;
+                }
+                break;
+            }
+            path.addNode(pathNode.getRow(), pathNode.getColumn());
+            pathNode = nextNode(pathNode.getRow(), pathNode.getColumn(), rowEnd, columnEnd);
         }
-        break;
-      }
-      path.addNode(pathNode.getRow(), pathNode.getColumn());
-      pathNode = nextNode(pathNode.getRow(), pathNode.getColumn(), rowEnd, columnEnd);
+        return path;
     }
-    return path;
-  }
 
-  // Gives the next closest node to the current that goes towards end node
-  public Node nextNode(int rowCurrent, int columnCurrent, int rowEnd, int columnEnd) {
-    // Diagonal path towards destination
-    if (rowCurrent != rowEnd && columnCurrent != columnEnd) {
-      // Top left
-      if (rowCurrent > rowEnd && columnCurrent > columnEnd) {
-        return new Node(rowCurrent - 1, columnCurrent - 1);
-      }
-      // Top right
-      else if (rowCurrent > rowEnd) {
-        return new Node(rowCurrent - 1, columnCurrent + 1);
-      }
-      // Bottom left
-      else if (columnCurrent > columnEnd) {
-        return new Node(rowCurrent + 1, columnCurrent - 1);
-      }
-      // Bottom right
-      else {
-        return new Node(rowCurrent + 1, columnCurrent + 1);
-      }
+    // Gives the next closest node to the current that goes towards end node
+    public Node nextNode(int rowCurrent, int columnCurrent, int rowEnd, int columnEnd) {
+        // Diagonal path towards destination
+        if (rowCurrent != rowEnd && columnCurrent != columnEnd) {
+            // Top left
+            if (rowCurrent > rowEnd && columnCurrent > columnEnd) {
+                return new Node(rowCurrent - 1, columnCurrent - 1);
+            }
+            // Top right
+            else if (rowCurrent > rowEnd) {
+                return new Node(rowCurrent - 1, columnCurrent + 1);
+            }
+            // Bottom left
+            else if (columnCurrent > columnEnd) {
+                return new Node(rowCurrent + 1, columnCurrent - 1);
+            }
+            // Bottom right
+            else {
+                return new Node(rowCurrent + 1, columnCurrent + 1);
+            }
+        }
+        // Current is in the correct column
+        // Up
+        else if (rowEnd > rowCurrent) {
+            return new Node(rowCurrent + 1, columnCurrent);
+        }
+        // Down
+        else if (rowEnd < rowCurrent) {
+            return new Node(rowCurrent - 1, columnCurrent);
+        }
+        // Current is in the correct row
+        // Left
+        else if (columnEnd < columnCurrent) {
+            return new Node(rowCurrent, columnCurrent - 1);
+        }
+        // Right
+        else if (columnEnd > columnCurrent) {
+            return new Node(rowCurrent, columnCurrent + 1);
+        }
+        // Current equals End
+        return null;
     }
-    // Current is in the correct column
-    // Up
-    else if (rowEnd > rowCurrent) {
-      return new Node(rowCurrent + 1, columnCurrent);
-    }
-    // Down
-    else if (rowEnd < rowCurrent) {
-      return new Node(rowCurrent - 1, columnCurrent);
-    }
-    // Current is in the correct row
-    // Left
-    else if (columnEnd < columnCurrent) {
-      return new Node(rowCurrent, columnCurrent - 1);
-    }
-    // Right
-    else if (columnEnd > columnCurrent) {
-      return new Node(rowCurrent, columnCurrent + 1);
-    }
-    // Current equals End
-    return null;
-  }
 
-  public Path nonEnemyPath(int rowCurrent, int columnCurrent, int rowEnd, int columnEnd,
+    public Path nonEnemyPath(int rowCurrent, int columnCurrent, int rowEnd, int columnEnd,
       BaseUnit.Team team, HashMap<Node, Boolean> exploredNodes) {
-    exploredNodes.put(new Node(rowCurrent, columnCurrent), true);
-    ArrayList<Node> adjacentNodes = getValidAdjacentNodes(rowCurrent, columnCurrent, team,
-        exploredNodes);
-    ArrayList<Path> adjacentPaths = new ArrayList<>();
-    for (Node node : adjacentNodes) {
-      Path path = new Path();
-      path.addNode(node.getRow(), node.getColumn());
-      Path nextPath = pathFinder(node.getRow(), node.getColumn(), rowEnd, columnEnd, team,
+        exploredNodes.put(new Node(rowCurrent, columnCurrent), true);
+        ArrayList<Node> adjacentNodes = getValidAdjacentNodes(rowCurrent, columnCurrent, team,
           exploredNodes);
-      if (nextPath != null) {
-        path.appendPath(nextPath);
-      } else {
-        continue;
-      }
-      adjacentPaths.add(path);
+        ArrayList<Path> adjacentPaths = new ArrayList<>();
+        for (Node node : adjacentNodes) {
+            Path path = new Path();
+            path.addNode(node.getRow(), node.getColumn());
+            Path nextPath = pathFinder(node.getRow(), node.getColumn(), rowEnd, columnEnd, team,
+              exploredNodes);
+            if (nextPath != null) {
+                path.appendPath(nextPath);
+            } else {
+                continue;
+            }
+            adjacentPaths.add(path);
+        }
+        Path shortestPath = null;
+        for (Path path : adjacentPaths) {
+            if (shortestPath == null && path.getLast().getRow() == rowEnd
+              && path.getLast().getColumn() == columnEnd) {
+                shortestPath = path;
+            } else if (shortestPath != null && path.getLength() < shortestPath.getLength()
+              && path.getLast().getRow() == rowEnd
+              && path.getLast().getColumn() == columnEnd) {
+                shortestPath = path;
+            }
+        }
+        return shortestPath;
     }
-    Path shortestPath = null;
-    for (Path path : adjacentPaths) {
-      if (shortestPath == null && path.getLast().getRow() == rowEnd
-          && path.getLast().getColumn() == columnEnd) {
-        shortestPath = path;
-      } else if (shortestPath != null && path.getLength() < shortestPath.getLength()
-          && path.getLast().getRow() == rowEnd
-          && path.getLast().getColumn() == columnEnd) {
-        shortestPath = path;
-      }
-    }
-    return shortestPath;
-  }
 
-  public boolean checkTeam(BoardCell cell1, BaseUnit.Team team) {
-    // If there is no cell in the board than it is a square that can be traversed
-    if (cell1.unit == null) {
-      return true;
-    } else {
-      return cell1.unit.getTeam() == team;
+    public boolean checkTeam(BoardCell cell1, BaseUnit.Team team) {
+        // If there is no cell in the board than it is a square that can be traversed
+        if (cell1.unit == null) {
+            return true;
+        } else {
+            return cell1.unit.getTeam() == team;
+        }
     }
-  }
 
-  public ArrayList<Node> getValidAdjacentNodes(int rowCurrent, int columnCurrent,
+    public ArrayList<Node> getValidAdjacentNodes(int rowCurrent, int columnCurrent,
       BaseUnit.Team team, HashMap<Node, Boolean> exploredNodes) {
-    ArrayList<Node> nodes = new ArrayList<>();
-    ArrayList<Node> validNodes = new ArrayList<>();
-    // Diagonal Up-Left
-    nodes.add(new Node(rowCurrent - 1, columnCurrent - 1));
-    // Up
-    nodes.add(new Node(rowCurrent - 1, columnCurrent));
-    // Diagonal Up-Right
-    nodes.add(new Node(rowCurrent - 1, columnCurrent + 1));
-    // Left
-    nodes.add(new Node(rowCurrent, columnCurrent - 1));
-    // Right
-    nodes.add(new Node(rowCurrent, columnCurrent + 1));
-    // Diagonal Down-Left
-    nodes.add(new Node(rowCurrent + 1, columnCurrent - 1));
-    // Down
-    nodes.add(new Node(rowCurrent + 1, columnCurrent));
-    // Diagonal Down-Right
-    nodes.add(new Node(rowCurrent + 1, columnCurrent + 1));
-    for (Node node : nodes) {
-      if (node.getRow() >= 0 && node.getRow() < board.length && node.getColumn() >= 0 &&
-          node.getColumn() < board[0].length && checkTeam(board[node.getRow()][node.getColumn()],
-          team)
-          && !exploredNodes.containsKey(node)) {
-        validNodes.add(node);
-        exploredNodes.put(node, true);
-      }
+        ArrayList<Node> nodes = new ArrayList<>();
+        ArrayList<Node> validNodes = new ArrayList<>();
+        // Diagonal Up-Left
+        nodes.add(new Node(rowCurrent - 1, columnCurrent - 1));
+        // Up
+        nodes.add(new Node(rowCurrent - 1, columnCurrent));
+        // Diagonal Up-Right
+        nodes.add(new Node(rowCurrent - 1, columnCurrent + 1));
+        // Left
+        nodes.add(new Node(rowCurrent, columnCurrent - 1));
+        // Right
+        nodes.add(new Node(rowCurrent, columnCurrent + 1));
+        // Diagonal Down-Left
+        nodes.add(new Node(rowCurrent + 1, columnCurrent - 1));
+        // Down
+        nodes.add(new Node(rowCurrent + 1, columnCurrent));
+        // Diagonal Down-Right
+        nodes.add(new Node(rowCurrent + 1, columnCurrent + 1));
+        for (Node node : nodes) {
+            if (node.getRow() >= 0 && node.getRow() < board.length && node.getColumn() >= 0 &&
+              node.getColumn() < board[0].length && checkTeam(
+              board[node.getRow()][node.getColumn()],
+              team)
+              && !exploredNodes.containsKey(node)) {
+                validNodes.add(node);
+                exploredNodes.put(node, true);
+            }
+        }
+        return validNodes;
     }
-    return validNodes;
-  }
 
 }

--- a/Model/BoardCell.java
+++ b/Model/BoardCell.java
@@ -4,9 +4,9 @@ import Units.*;
 
 public class BoardCell {
 
-  public BaseUnit unit;
+    public BaseUnit unit;
 
-  public BoardCell(BaseUnit unit) {
-    this.unit = unit;
-  }
+    public BoardCell(BaseUnit unit) {
+        this.unit = unit;
+    }
 }

--- a/Model/BoardCell.java
+++ b/Model/BoardCell.java
@@ -1,7 +1,11 @@
 package Model;
+
 import Units.*;
+
 public class BoardCell {
+
     public BaseUnit unit;
+
     public BoardCell(BaseUnit unit) {
         this.unit = unit;
     }

--- a/Model/Node.java
+++ b/Model/Node.java
@@ -4,47 +4,47 @@ import java.util.Objects;
 
 public class Node {
 
-  private int row;
-  private int column;
+    private int row;
+    private int column;
 
-  public Node(int row, int column) {
-    this.row = row;
-    this.column = column;
-  }
-
-  public int getColumn() {
-    return column;
-  }
-
-  public int getRow() {
-    return row;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
+    public Node(int row, int column) {
+        this.row = row;
+        this.column = column;
     }
-    if (o == null) {
-      return false;
-    }
-    if (!(o instanceof Node)) {
-      return false;
-    }
-    Node n = (Node) o;
-    return this.row == n.row && this.column == n.column;
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(row, column);
-  }
+    public int getColumn() {
+        return column;
+    }
 
-  @Override
-  public String toString() {
-    String s = "";
-    s = s + row;
-    s = s + column;
-    return s;
-  }
+    public int getRow() {
+        return row;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof Node)) {
+            return false;
+        }
+        Node n = (Node) o;
+        return this.row == n.row && this.column == n.column;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(row, column);
+    }
+
+    @Override
+    public String toString() {
+        String s = "";
+        s = s + row;
+        s = s + column;
+        return s;
+    }
 }

--- a/Model/Node.java
+++ b/Model/Node.java
@@ -3,9 +3,11 @@ package Model;
 import java.util.Objects;
 
 public class Node {
+
     private int row;
     private int column;
-    public Node(int row, int column){
+
+    public Node(int row, int column) {
         this.row = row;
         this.column = column;
     }
@@ -20,13 +22,13 @@ public class Node {
 
     @Override
     public boolean equals(Object o) {
-        if(o == this) {
+        if (o == this) {
             return true;
         }
-        if(o == null) {
+        if (o == null) {
             return false;
         }
-        if(!(o instanceof Node)) {
+        if (!(o instanceof Node)) {
             return false;
         }
         Node n = (Node) o;

--- a/Model/Path.java
+++ b/Model/Path.java
@@ -6,48 +6,48 @@ import java.util.Objects;
 // A path contains nodes and goes from one location to another
 public class Path {
 
-  public ArrayList<Node> path;
+    public ArrayList<Node> path;
 
-  public Path() {
-    path = new ArrayList<>();
-  }
-
-  public void addNode(int row, int column) {
-    path.add(new Node(row, column));
-  }
-
-  public Node getLast() {
-    return path.get(path.size() - 1);
-  }
-
-  public Node getFirst() {
-    return path.get(0);
-  }
-
-  public void appendPath(Path path) {
-    this.path.addAll(path.path);
-  }
-
-  public int getLength() {
-    return path.size();
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (o == this) {
-      return true;
+    public Path() {
+        path = new ArrayList<>();
     }
-    if (o == null) {
-      return false;
-    }
-    if (!(o instanceof Path p)) {
-      return false;
-    }
-    return this.path.equals(p.path);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.path);
-  }
+    public void addNode(int row, int column) {
+        path.add(new Node(row, column));
+    }
+
+    public Node getLast() {
+        return path.get(path.size() - 1);
+    }
+
+    public Node getFirst() {
+        return path.get(0);
+    }
+
+    public void appendPath(Path path) {
+        this.path.addAll(path.path);
+    }
+
+    public int getLength() {
+        return path.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof Path p)) {
+            return false;
+        }
+        return this.path.equals(p.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.path);
+    }
 }

--- a/Model/Path.java
+++ b/Model/Path.java
@@ -4,10 +4,13 @@ import java.util.ArrayList;
 
 // A path contains nodes and goes from one location to another
 public class Path {
+
     public ArrayList<Node> path;
-    public Path(){
+
+    public Path() {
         path = new ArrayList<>();
     }
+
     public void addNode(int row, int column) {
         path.add(new Node(row, column));
     }

--- a/Model/TestBoard.java
+++ b/Model/TestBoard.java
@@ -5,30 +5,30 @@ import Units.*;
 
 public class TestBoard extends Board {
 
-  // Random board generator for testing purposes
-  public TestBoard() {
-    Random randomGenerator = new Random();
-    int x = randomGenerator.nextInt(20) + 1;
-    int y = randomGenerator.nextInt(20) + 1;
-    board = new BoardCell[x][y];
-    for (int row = 0; row < board.length; row++) {
-      for (int column = 0; column < board[row].length; column++) {
-        int value = randomGenerator.nextInt(3);
-        BaseUnit unit;
-        switch (value) {
-          case 0:
-            unit = new Civilian(BaseUnit.Team.BLUE);
-            break;
-          case 1:
-            unit = new Tradesman();
-            break;
-          default:
-            // No unit
-            unit = null;
+    // Random board generator for testing purposes
+    public TestBoard() {
+        Random randomGenerator = new Random();
+        int x = randomGenerator.nextInt(20) + 1;
+        int y = randomGenerator.nextInt(20) + 1;
+        board = new BoardCell[x][y];
+        for (int row = 0; row < board.length; row++) {
+            for (int column = 0; column < board[row].length; column++) {
+                int value = randomGenerator.nextInt(3);
+                BaseUnit unit;
+                switch (value) {
+                    case 0:
+                        unit = new Civilian(BaseUnit.Team.BLUE);
+                        break;
+                    case 1:
+                        unit = new Tradesman();
+                        break;
+                    default:
+                        // No unit
+                        unit = null;
+                }
+                board[row][column] = new BoardCell(unit);
+            }
         }
-        board[row][column] = new BoardCell(unit);
-      }
-    }
 
-  }
+    }
 }

--- a/Model/TestBoard.java
+++ b/Model/TestBoard.java
@@ -14,7 +14,7 @@ public class TestBoard extends Board {
             for (int column = 0; column < board[row].length; column++) {
                 int value = randomGenerator.nextInt(3);
                 BaseUnit unit;
-                switch(value) {
+                switch (value) {
                     case 0:
                         unit = new Civilian();
                         break;

--- a/Test/BoardUnitTests.java
+++ b/Test/BoardUnitTests.java
@@ -17,628 +17,629 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class BoardUnitTests {
 
-  private Board board;
+    private Board board;
 
-  @BeforeEach
-  void initAll() {
-    board = new Board(5, 10);
-  }
+    @BeforeEach
+    void initAll() {
+        board = new Board(5, 10);
+    }
 
-  @Test
-  void testNextNode() {
-    // Direct diagonal up-left
-    assertEquals(new Node(4, 4), board.nextNode(5, 5, 0, 0));
-    // Direct diagonal up-right
-    assertEquals(new Node(4, 6), board.nextNode(5, 5, 0, 10));
-    // Direct diagonal bottom-left
-    assertEquals(new Node(6, 4), board.nextNode(5, 5, 10, 0));
-    // Direct diagonal bottom-right
-    assertEquals(new Node(6, 6), board.nextNode(5, 5, 10, 10));
-    // Direct up
-    assertEquals(new Node(4, 5), board.nextNode(5, 5, 0, 5));
-    // Direct right
-    assertEquals(new Node(5, 6), board.nextNode(5, 5, 5, 10));
-    // Direct down
-    assertEquals(new Node(6, 5), board.nextNode(5, 5, 10, 5));
-    // Direct left
-    assertEquals(new Node(5, 4), board.nextNode(5, 5, 5, 0));
+    @Test
+    void testNextNode() {
+        // Direct diagonal up-left
+        assertEquals(new Node(4, 4), board.nextNode(5, 5, 0, 0));
+        // Direct diagonal up-right
+        assertEquals(new Node(4, 6), board.nextNode(5, 5, 0, 10));
+        // Direct diagonal bottom-left
+        assertEquals(new Node(6, 4), board.nextNode(5, 5, 10, 0));
+        // Direct diagonal bottom-right
+        assertEquals(new Node(6, 6), board.nextNode(5, 5, 10, 10));
+        // Direct up
+        assertEquals(new Node(4, 5), board.nextNode(5, 5, 0, 5));
+        // Direct right
+        assertEquals(new Node(5, 6), board.nextNode(5, 5, 5, 10));
+        // Direct down
+        assertEquals(new Node(6, 5), board.nextNode(5, 5, 10, 5));
+        // Direct left
+        assertEquals(new Node(5, 4), board.nextNode(5, 5, 5, 0));
 
-    // TODO: add non straight lines between two point test cases
-  }
+        // TODO: add non straight lines between two point test cases
+    }
 
-  @Test
-  void testNextNodeWithEnemy() {
-    // TODO: add test cases for not going into enemy units
+    @Test
+    void testNextNodeWithEnemy() {
+        // TODO: add test cases for not going into enemy units
         /* 0---0
            -X-X-
            --0--
            -X-X-
            0---0 */
-    board.board[0][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[0][4] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[4][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[4][4] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    // Diagonal up-left
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(1, 2)));
-    // Diagonal up-right
-    assertEquals(board.nonEnemyPath(2, 2, 0, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(1, 2)));
-    // Diagonal bottom-left
-    assertEquals(board.nonEnemyPath(2, 2, 4, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(2, 1)));
-    // Diagonal bottom-right
-    assertEquals(board.nonEnemyPath(2, 2, 4, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(2, 3)));
+        board.board[0][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[0][4] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[4][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[4][4] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        // Diagonal up-left
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(1, 2)));
+        // Diagonal up-right
+        assertEquals(board.nonEnemyPath(2, 2, 0, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(1, 2)));
+        // Diagonal bottom-left
+        assertEquals(board.nonEnemyPath(2, 2, 4, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(2, 1)));
+        // Diagonal bottom-right
+        assertEquals(board.nonEnemyPath(2, 2, 4, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(2, 3)));
         /* 0---0
            -XXX-
            --0--
            -XXX-
            0---0 */
-    board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    // Diagonal up-left
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(2, 1)));
-    // Diagonal up-right
-    assertEquals(board.nonEnemyPath(2, 2, 0, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(2, 3)));
-    // Diagonal bottom-left
-    assertEquals(board.nonEnemyPath(2, 2, 4, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(2, 1)));
-    // Diagonal bottom-right
-    assertEquals(board.nonEnemyPath(2, 2, 4, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
-        (new Node(2, 3)));
-  }
+        board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        // Diagonal up-left
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(2, 1)));
+        // Diagonal up-right
+        assertEquals(board.nonEnemyPath(2, 2, 0, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(2, 3)));
+        // Diagonal bottom-left
+        assertEquals(board.nonEnemyPath(2, 2, 4, 0, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(2, 1)));
+        // Diagonal bottom-right
+        assertEquals(board.nonEnemyPath(2, 2, 4, 4, BaseUnit.Team.RED, new HashMap<>()).getFirst(),
+          (new Node(2, 3)));
+    }
 
-  @Test
-  void testGetValidAdjacentNodes() {
-    ArrayList<Node> everyAdjacent = new ArrayList<>();
-    everyAdjacent.add(new Node(1, 1));
-    everyAdjacent.add(new Node(1, 2));
-    everyAdjacent.add(new Node(1, 3));
-    everyAdjacent.add(new Node(2, 1));
-    everyAdjacent.add(new Node(2, 3));
-    everyAdjacent.add(new Node(3, 1));
-    everyAdjacent.add(new Node(3, 2));
-    everyAdjacent.add(new Node(3, 3));
-    ArrayList<Node> emptyList = new ArrayList<>();
-    ArrayList<Node> modularList = new ArrayList<>();
+    @Test
+    void testGetValidAdjacentNodes() {
+        ArrayList<Node> everyAdjacent = new ArrayList<>();
+        everyAdjacent.add(new Node(1, 1));
+        everyAdjacent.add(new Node(1, 2));
+        everyAdjacent.add(new Node(1, 3));
+        everyAdjacent.add(new Node(2, 1));
+        everyAdjacent.add(new Node(2, 3));
+        everyAdjacent.add(new Node(3, 1));
+        everyAdjacent.add(new Node(3, 2));
+        everyAdjacent.add(new Node(3, 3));
+        ArrayList<Node> emptyList = new ArrayList<>();
+        ArrayList<Node> modularList = new ArrayList<>();
 
         /* 0----
            -----
            --0--
            -----
            ----- */
-    board.board[0][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
-        everyAdjacent);
+        board.board[0][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          everyAdjacent);
 
         /* 0----
            -XXX-
            -X0X-
            -XXX-
            ----- */
-    board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()), emptyList);
+        board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          emptyList);
 
         /* 0----
            -XXX-
            -X0--
            -XXX-
            ----- */
-    board.board[2][3] = new BoardCell(null);
-    modularList.add(new Node(2, 3));
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
-        modularList);
+        board.board[2][3] = new BoardCell(null);
+        modularList.add(new Node(2, 3));
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          modularList);
 
         /* 0----
            --XX-
            -X0--
            -XXX-
            ----- */
-    board.board[1][1] = new BoardCell(null);
-    modularList.add(0, new Node(1, 1));
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
-        modularList);
+        board.board[1][1] = new BoardCell(null);
+        modularList.add(0, new Node(1, 1));
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          modularList);
 
         /* 0----
            -000-
            -000-
            -000-
            ----- */
-    board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
-        everyAdjacent);
+        board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          everyAdjacent);
 
         /* 0----
            -000-
            -00--
            -000-
            ----- */
-    board.board[2][3] = new BoardCell(null);
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
-        everyAdjacent);
+        board.board[2][3] = new BoardCell(null);
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          everyAdjacent);
 
         /* 0----
            --00-
            -00--
            -000-
            ----- */
-    board.board[1][1] = new BoardCell(null);
-    assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
-        everyAdjacent);
+        board.board[1][1] = new BoardCell(null);
+        assertEquals(board.getValidAdjacentNodes(2, 2, BaseUnit.Team.RED, new HashMap<>()),
+          everyAdjacent);
 
-  }
+    }
 
-  @Test
-  void testNonEnemyPath() {
+    @Test
+    void testNonEnemyPath() {
         /* 0----
            -----
            --0--
            -----
            ----- */
-    board.board[0][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    Path path = new Path();
-    path.addNode(1, 1);
-    path.addNode(0, 0);
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, BaseUnit.Team.RED, new HashMap<>()),
-        path);
+        board.board[0][0] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        Path path = new Path();
+        path.addNode(1, 1);
+        path.addNode(0, 0);
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, BaseUnit.Team.RED, new HashMap<>()),
+          path);
 
         /* 0----
            -XXX-
            -X0X-
            -XXX-
            ----- */
-    board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
-    assertNull(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()));
+        board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.BLUE));
+        assertNull(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()));
 
         /* 0----
            -XXX-
            -X0--
            -XXX-
            ----- */
-    board.board[2][3] = new BoardCell(null);
-    path = new Path();
-    path.addNode(2, 3);
-    path.addNode(1, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
-        path);
+        board.board[2][3] = new BoardCell(null);
+        path = new Path();
+        path.addNode(2, 3);
+        path.addNode(1, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
+          path);
 
         /* 0----
            --XX-
            -X0--
            -XXX-
            ----- */
-    board.board[1][1] = new BoardCell(null);
-    path = new Path();
-    path.addNode(1, 1);
-    path.addNode(0, 0);
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
-        path);
+        board.board[1][1] = new BoardCell(null);
+        path = new Path();
+        path.addNode(1, 1);
+        path.addNode(0, 0);
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
+          path);
 
         /* 0----
            -000-
            -000-
            -000-
            ----- */
-    board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
-        path);
+        board.board[1][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[1][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[1][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[2][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[3][1] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[3][2] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        board.board[3][3] = new BoardCell(new Civilian(BaseUnit.Team.RED));
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
+          path);
 
         /* 0----
            -000-
            -00--
            -000-
            ----- */
-    board.board[2][3] = new BoardCell(null);
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
-        path);
+        board.board[2][3] = new BoardCell(null);
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
+          path);
 
         /* 0----
            --00-
            -00--
            -000-
            ----- */
-    board.board[1][1] = new BoardCell(null);
-    assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
-        path);
+        board.board[1][1] = new BoardCell(null);
+        assertEquals(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()),
+          path);
 
         /* 0---------
            XXXXXXXXXX
            -00-------
            -000------
            ---------- */
-    board.board[1][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][1] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][2] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][3] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][4] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][5] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][6] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][7] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][8] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][9] = new BoardCell(new Civilian(Team.BLUE));
-    assertNull(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()));
-  }
+        board.board[1][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][1] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][2] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][3] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][4] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][5] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][6] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][7] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][8] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][9] = new BoardCell(new Civilian(Team.BLUE));
+        assertNull(board.nonEnemyPath(2, 2, 0, 0, Team.RED, new HashMap<>()));
+    }
 
-  @Test
-  void testPathFinder() {
+    @Test
+    void testPathFinder() {
         /* 0---------
            XXXXXXXXXX
            ----------
            ----------
            ---------0 */
-    board.board[0][0] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][1] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][2] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][3] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][4] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][5] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][6] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][7] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][8] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][9] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[4][9] = new BoardCell(new Civilian(Team.RED));
-    assertNull(board.pathFinder(4, 9, 0, 0, Team.RED, new HashMap<>()));
+        board.board[0][0] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][1] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][2] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][3] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][4] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][5] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][6] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][7] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][8] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][9] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[4][9] = new BoardCell(new Civilian(Team.RED));
+        assertNull(board.pathFinder(4, 9, 0, 0, Team.RED, new HashMap<>()));
 
         /* 0---------
            ----------
            ----------
            ----------
            ---------0 */
-    board.board[1][0] = new BoardCell(null);
-    board.board[1][1] = new BoardCell(null);
-    board.board[1][2] = new BoardCell(null);
-    board.board[1][3] = new BoardCell(null);
-    board.board[1][4] = new BoardCell(null);
-    board.board[1][5] = new BoardCell(null);
-    board.board[1][6] = new BoardCell(null);
-    board.board[1][7] = new BoardCell(null);
-    board.board[1][8] = new BoardCell(null);
-    board.board[1][9] = new BoardCell(null);
-    Path path = new Path();
-    path.addNode(3, 8);
-    path.addNode(2, 7);
-    path.addNode(1, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(4, 9, 0, 0, Team.RED, new HashMap<>()), path);
+        board.board[1][0] = new BoardCell(null);
+        board.board[1][1] = new BoardCell(null);
+        board.board[1][2] = new BoardCell(null);
+        board.board[1][3] = new BoardCell(null);
+        board.board[1][4] = new BoardCell(null);
+        board.board[1][5] = new BoardCell(null);
+        board.board[1][6] = new BoardCell(null);
+        board.board[1][7] = new BoardCell(null);
+        board.board[1][8] = new BoardCell(null);
+        board.board[1][9] = new BoardCell(null);
+        Path path = new Path();
+        path.addNode(3, 8);
+        path.addNode(2, 7);
+        path.addNode(1, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(4, 9, 0, 0, Team.RED, new HashMap<>()), path);
 
         /* 0---------
            ----------
            ----------
            ----------
            0--------- */
-    board.board[4][0] = new BoardCell(new Civilian(Team.RED));
-    board.board[4][9] = new BoardCell(new Civilian(null));
-    path = new Path();
-    path.addNode(3, 0);
-    path.addNode(2, 0);
-    path.addNode(1, 0);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(4, 0, 0, 0, Team.RED, new HashMap<>()), path);
+        board.board[4][0] = new BoardCell(new Civilian(Team.RED));
+        board.board[4][9] = new BoardCell(new Civilian(null));
+        path = new Path();
+        path.addNode(3, 0);
+        path.addNode(2, 0);
+        path.addNode(1, 0);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(4, 0, 0, 0, Team.RED, new HashMap<>()), path);
 
         /* 0--------0
            ----------
            ----------
            ----------
            ---------- */
-    board.board[4][0] = new BoardCell(null);
-    board.board[0][9] = new BoardCell(new Civilian(Team.RED));
-    path = new Path();
-    path.addNode(0, 8);
-    path.addNode(0, 7);
-    path.addNode(0, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(0, 9, 0, 0, Team.RED, new HashMap<>()), path);
+        board.board[4][0] = new BoardCell(null);
+        board.board[0][9] = new BoardCell(new Civilian(Team.RED));
+        path = new Path();
+        path.addNode(0, 8);
+        path.addNode(0, 7);
+        path.addNode(0, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(0, 9, 0, 0, Team.RED, new HashMap<>()), path);
 
         /* 0XXXXXXXXX
            XXXXXXXXXX
            XXXX0-XXXX
            XXXXXXXXXX
            XXXXXXXXXX */
-    populateBoard(new Civilian(Team.BLUE));
-    board.board[0][0] = new BoardCell(new Civilian(Team.RED));
-    board.board[2][4] = new BoardCell(new Civilian(Team.RED));
-    board.board[2][5] = new BoardCell(null);
-    assertNull(board.pathFinder(2, 5, 0, 0, Team.RED, new HashMap<>()));
+        populateBoard(new Civilian(Team.BLUE));
+        board.board[0][0] = new BoardCell(new Civilian(Team.RED));
+        board.board[2][4] = new BoardCell(new Civilian(Team.RED));
+        board.board[2][5] = new BoardCell(null);
+        assertNull(board.pathFinder(2, 5, 0, 0, Team.RED, new HashMap<>()));
 
         /* 0---------
            XXXXXXXXX-
            -------0X-
            -XXXXXXXX-
            ---------- */
-    populateBoard(null);
-    board.board[0][0] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][1] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][2] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][3] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][4] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][5] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][6] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][7] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][8] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[2][7] = new BoardCell(new Civilian(Team.RED));
-    board.board[2][8] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][1] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][2] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][3] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][4] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][5] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][6] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][7] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[3][8] = new BoardCell(new Civilian(Team.BLUE));
-    path = new Path();
-    path.addNode(2, 6);
-    path.addNode(2, 5);
-    path.addNode(2, 4);
-    path.addNode(2, 3);
-    path.addNode(2, 2);
-    path.addNode(2, 1);
-    path.addNode(3, 0);
-    path.addNode(4, 1);
-    path.addNode(4, 2);
-    path.addNode(4, 3);
-    path.addNode(4, 4);
-    path.addNode(4, 5);
-    path.addNode(4, 6);
-    path.addNode(4, 7);
-    path.addNode(4, 8);
-    path.addNode(3, 9);
-    path.addNode(2, 9);
-    path.addNode(1, 9);
-    path.addNode(0, 8);
-    path.addNode(0, 7);
-    path.addNode(0, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(2, 7, 0, 0, Team.RED, new HashMap<>()), path);
+        populateBoard(null);
+        board.board[0][0] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][1] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][2] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][3] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][4] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][5] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][6] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][7] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][8] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[2][7] = new BoardCell(new Civilian(Team.RED));
+        board.board[2][8] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][1] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][2] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][3] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][4] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][5] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][6] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][7] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[3][8] = new BoardCell(new Civilian(Team.BLUE));
+        path = new Path();
+        path.addNode(2, 6);
+        path.addNode(2, 5);
+        path.addNode(2, 4);
+        path.addNode(2, 3);
+        path.addNode(2, 2);
+        path.addNode(2, 1);
+        path.addNode(3, 0);
+        path.addNode(4, 1);
+        path.addNode(4, 2);
+        path.addNode(4, 3);
+        path.addNode(4, 4);
+        path.addNode(4, 5);
+        path.addNode(4, 6);
+        path.addNode(4, 7);
+        path.addNode(4, 8);
+        path.addNode(3, 9);
+        path.addNode(2, 9);
+        path.addNode(1, 9);
+        path.addNode(0, 8);
+        path.addNode(0, 7);
+        path.addNode(0, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(2, 7, 0, 0, Team.RED, new HashMap<>()), path);
 
         /* 0000000000
            0000000000
            0000000000
            0000000000
            0000000000 */
-    populateBoard(new Civilian(Team.RED));
-    path = new Path();
-    path.addNode(3, 8);
-    path.addNode(2, 7);
-    path.addNode(1, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(4, 9, 0, 0, Team.RED, new HashMap<>()), path);
+        populateBoard(new Civilian(Team.RED));
+        path = new Path();
+        path.addNode(3, 8);
+        path.addNode(2, 7);
+        path.addNode(1, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(4, 9, 0, 0, Team.RED, new HashMap<>()), path);
 
         /* X---------
            0000000000
            ----------
            ----------
            ---------X */
-    board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][0] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][1] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][2] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][3] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][4] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][5] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][6] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][7] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][8] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][9] = new BoardCell(new Civilian(Team.RED));
-    board.board[4][9] = new BoardCell(new Civilian(Team.BLUE));
-    assertNull(board.pathFinder(4, 9, 0, 0, Team.BLUE, new HashMap<>()));
+        board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][0] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][1] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][2] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][3] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][4] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][5] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][6] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][7] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][8] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][9] = new BoardCell(new Civilian(Team.RED));
+        board.board[4][9] = new BoardCell(new Civilian(Team.BLUE));
+        assertNull(board.pathFinder(4, 9, 0, 0, Team.BLUE, new HashMap<>()));
 
         /* X---------
            ----------
            ----------
            ----------
            ---------X */
-    populateBoard(null);
-    board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[4][9] = new BoardCell(new Civilian(Team.BLUE));
-    path = new Path();
-    path.addNode(3, 8);
-    path.addNode(2, 7);
-    path.addNode(1, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(4, 9, 0, 0, Team.BLUE, new HashMap<>()), path);
+        populateBoard(null);
+        board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[4][9] = new BoardCell(new Civilian(Team.BLUE));
+        path = new Path();
+        path.addNode(3, 8);
+        path.addNode(2, 7);
+        path.addNode(1, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(4, 9, 0, 0, Team.BLUE, new HashMap<>()), path);
 
         /* X---------
            ----------
            ----------
            ----------
            X--------- */
-    board.board[4][9] = new BoardCell(null);
-    board.board[4][0] = new BoardCell(new Civilian(Team.BLUE));
-    path = new Path();
-    path.addNode(3, 0);
-    path.addNode(2, 0);
-    path.addNode(1, 0);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(4, 0, 0, 0, Team.BLUE, new HashMap<>()), path);
+        board.board[4][9] = new BoardCell(null);
+        board.board[4][0] = new BoardCell(new Civilian(Team.BLUE));
+        path = new Path();
+        path.addNode(3, 0);
+        path.addNode(2, 0);
+        path.addNode(1, 0);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(4, 0, 0, 0, Team.BLUE, new HashMap<>()), path);
 
         /* X--------X
            ----------
            ----------
            ----------
            ---------- */
-    board.board[4][0] = new BoardCell(null);
-    board.board[0][9] = new BoardCell(new Civilian(Team.BLUE));
-    path = new Path();
-    path.addNode(0, 8);
-    path.addNode(0, 7);
-    path.addNode(0, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(0, 9, 0, 0, Team.BLUE, new HashMap<>()), path);
+        board.board[4][0] = new BoardCell(null);
+        board.board[0][9] = new BoardCell(new Civilian(Team.BLUE));
+        path = new Path();
+        path.addNode(0, 8);
+        path.addNode(0, 7);
+        path.addNode(0, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(0, 9, 0, 0, Team.BLUE, new HashMap<>()), path);
 
         /* X000000000
            0000000000
            0000X-0000
            0000000000
            0000000000 */
-    populateBoard(new Civilian(Team.RED));
-    board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[2][4] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[2][5] = new BoardCell(null);
-    assertNull(board.pathFinder(2, 5, 0, 0, Team.BLUE, new HashMap<>()));
+        populateBoard(new Civilian(Team.RED));
+        board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[2][4] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[2][5] = new BoardCell(null);
+        assertNull(board.pathFinder(2, 5, 0, 0, Team.BLUE, new HashMap<>()));
 
         /* X---------
            000000000-
            -------X0-
            -00000000-
            ---------- */
-    populateBoard(null);
-    board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[1][0] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][1] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][2] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][3] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][4] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][5] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][6] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][7] = new BoardCell(new Civilian(Team.RED));
-    board.board[1][8] = new BoardCell(new Civilian(Team.RED));
-    board.board[2][7] = new BoardCell(new Civilian(Team.BLUE));
-    board.board[2][8] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][1] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][2] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][3] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][4] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][5] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][6] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][7] = new BoardCell(new Civilian(Team.RED));
-    board.board[3][8] = new BoardCell(new Civilian(Team.RED));
-    path = new Path();
-    path.addNode(2, 6);
-    path.addNode(2, 5);
-    path.addNode(2, 4);
-    path.addNode(2, 3);
-    path.addNode(2, 2);
-    path.addNode(2, 1);
-    path.addNode(3, 0);
-    path.addNode(4, 1);
-    path.addNode(4, 2);
-    path.addNode(4, 3);
-    path.addNode(4, 4);
-    path.addNode(4, 5);
-    path.addNode(4, 6);
-    path.addNode(4, 7);
-    path.addNode(4, 8);
-    path.addNode(3, 9);
-    path.addNode(2, 9);
-    path.addNode(1, 9);
-    path.addNode(0, 8);
-    path.addNode(0, 7);
-    path.addNode(0, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(2, 7, 0, 0, Team.BLUE, new HashMap<>()), path);
+        populateBoard(null);
+        board.board[0][0] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[1][0] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][1] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][2] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][3] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][4] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][5] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][6] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][7] = new BoardCell(new Civilian(Team.RED));
+        board.board[1][8] = new BoardCell(new Civilian(Team.RED));
+        board.board[2][7] = new BoardCell(new Civilian(Team.BLUE));
+        board.board[2][8] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][1] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][2] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][3] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][4] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][5] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][6] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][7] = new BoardCell(new Civilian(Team.RED));
+        board.board[3][8] = new BoardCell(new Civilian(Team.RED));
+        path = new Path();
+        path.addNode(2, 6);
+        path.addNode(2, 5);
+        path.addNode(2, 4);
+        path.addNode(2, 3);
+        path.addNode(2, 2);
+        path.addNode(2, 1);
+        path.addNode(3, 0);
+        path.addNode(4, 1);
+        path.addNode(4, 2);
+        path.addNode(4, 3);
+        path.addNode(4, 4);
+        path.addNode(4, 5);
+        path.addNode(4, 6);
+        path.addNode(4, 7);
+        path.addNode(4, 8);
+        path.addNode(3, 9);
+        path.addNode(2, 9);
+        path.addNode(1, 9);
+        path.addNode(0, 8);
+        path.addNode(0, 7);
+        path.addNode(0, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(2, 7, 0, 0, Team.BLUE, new HashMap<>()), path);
 
         /* XXXXXXXXXX
            XXXXXXXXXX
            XXXXXXXXXX
            XXXXXXXXXX
            XXXXXXXXXX */
-    populateBoard(new Civilian(Team.BLUE));
-    path = new Path();
-    path.addNode(3, 8);
-    path.addNode(2, 7);
-    path.addNode(1, 6);
-    path.addNode(0, 5);
-    path.addNode(0, 4);
-    path.addNode(0, 3);
-    path.addNode(0, 2);
-    path.addNode(0, 1);
-    path.addNode(0, 0);
-    assertEquals(board.pathFinder(4, 9, 0, 0, Team.BLUE, new HashMap<>()), path);
+        populateBoard(new Civilian(Team.BLUE));
+        path = new Path();
+        path.addNode(3, 8);
+        path.addNode(2, 7);
+        path.addNode(1, 6);
+        path.addNode(0, 5);
+        path.addNode(0, 4);
+        path.addNode(0, 3);
+        path.addNode(0, 2);
+        path.addNode(0, 1);
+        path.addNode(0, 0);
+        assertEquals(board.pathFinder(4, 9, 0, 0, Team.BLUE, new HashMap<>()), path);
 
-    // Out of bounds start
-    assertNull(board.pathFinder(-1, -1, 0, 0, Team.BLUE, new HashMap<>()));
-    assertNull(board.pathFinder(11, 11, 0, 0, Team.BLUE, new HashMap<>()));
-    // Out of bounds end
-    assertNull(board.pathFinder(0, 0, -1, -1, Team.BLUE, new HashMap<>()));
-    assertNull(board.pathFinder(0, 0, 11, 11, Team.BLUE, new HashMap<>()));
+        // Out of bounds start
+        assertNull(board.pathFinder(-1, -1, 0, 0, Team.BLUE, new HashMap<>()));
+        assertNull(board.pathFinder(11, 11, 0, 0, Team.BLUE, new HashMap<>()));
+        // Out of bounds end
+        assertNull(board.pathFinder(0, 0, -1, -1, Team.BLUE, new HashMap<>()));
+        assertNull(board.pathFinder(0, 0, 11, 11, Team.BLUE, new HashMap<>()));
 
 
-  }
-
-  void populateBoard(BaseUnit unit) {
-    for (int i = 0; i < board.board.length; i++) {
-      for (int j = 0; j < board.board[0].length; j++) {
-        board.board[i][j] = new BoardCell(unit);
-      }
     }
-  }
+
+    void populateBoard(BaseUnit unit) {
+        for (int i = 0; i < board.board.length; i++) {
+            for (int j = 0; j < board.board[0].length; j++) {
+                board.board[i][j] = new BoardCell(unit);
+            }
+        }
+    }
 }

--- a/Test/BoardUnitTests.java
+++ b/Test/BoardUnitTests.java
@@ -1,12 +1,14 @@
 package Test;
 
 import Model.Board;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import Model.Node;
 import org.junit.jupiter.api.Test;
 
 public class BoardUnitTests {
+
     private final Board board = new Board();
 
     @Test
@@ -16,17 +18,17 @@ public class BoardUnitTests {
         // Direct diagonal up-right
         assertEquals(new Node(4, 6), board.nextNode(5, 5, 0, 10));
         // Direct diagonal bottom-left
-        assertEquals(new Node(6, 4),board.nextNode(5, 5, 10, 0));
+        assertEquals(new Node(6, 4), board.nextNode(5, 5, 10, 0));
         // Direct diagonal bottom-right
-        assertEquals(new Node(6, 6),board.nextNode(5, 5, 10, 10));
+        assertEquals(new Node(6, 6), board.nextNode(5, 5, 10, 10));
         // Direct up
-        assertEquals(new Node (4, 5),board.nextNode(5, 5, 0, 5));
+        assertEquals(new Node(4, 5), board.nextNode(5, 5, 0, 5));
         // Direct right
-        assertEquals(new Node (5, 6),board.nextNode(5, 5, 5, 10));
+        assertEquals(new Node(5, 6), board.nextNode(5, 5, 5, 10));
         // Direct down
-        assertEquals(new Node(6, 5),board.nextNode(5, 5, 10, 5));
+        assertEquals(new Node(6, 5), board.nextNode(5, 5, 10, 5));
         // Direct left
-        assertEquals(new Node(5, 4),board.nextNode(5, 5, 5, 0));
+        assertEquals(new Node(5, 4), board.nextNode(5, 5, 5, 0));
         // TODO: add non straight lines between two point test cases
     }
 }

--- a/Units/BaseUnit.java
+++ b/Units/BaseUnit.java
@@ -2,26 +2,26 @@ package Units;
 
 public abstract class BaseUnit {
 
-  char name = 'X';
-  int speed = 1;
-  int health = 100;
-  int rangeSight = 5;
-  int rangeAttack = 1;
-  int attack = 1;
-  int armor = 5;
-  // TODO: remove this or optimize where to put this information for determining unit faction
-  Team team;
+    char name = 'X';
+    int speed = 1;
+    int health = 100;
+    int rangeSight = 5;
+    int rangeAttack = 1;
+    int attack = 1;
+    int armor = 5;
+    // TODO: remove this or optimize where to put this information for determining unit faction
+    Team team;
 
-  public enum Team {
-    BLUE,
-    RED
-  }
+    public enum Team {
+        BLUE,
+        RED
+    }
 
-  public char getName() {
-    return name;
-  }
+    public char getName() {
+        return name;
+    }
 
-  public Team getTeam() {
-    return team;
-  }
+    public Team getTeam() {
+        return team;
+    }
 }

--- a/Units/BaseUnit.java
+++ b/Units/BaseUnit.java
@@ -1,6 +1,7 @@
 package Units;
 
 public abstract class BaseUnit {
+
     char name = 'X';
     int speed = 1;
     int health = 100;

--- a/Units/Civilian.java
+++ b/Units/Civilian.java
@@ -1,6 +1,7 @@
 package Units;
 
 public class Civilian extends FootUnit {
+
     public Civilian() {
         name = 'T';
         speed = 2;

--- a/Units/Civilian.java
+++ b/Units/Civilian.java
@@ -2,16 +2,16 @@ package Units;
 
 public class Civilian extends FootUnit {
 
-  // TODO: remove this or optimize where to put this information for determining unit faction
-  public Civilian(Team team) {
-    name = 'C';
-    speed = 2;
-    health = 100;
-    rangeSight = 4;
-    rangeAttack = 2;
-    attack = 5;
-    armor = 5;
-    rangeAct = 1;
-    super.team = team;
-  }
+    // TODO: remove this or optimize where to put this information for determining unit faction
+    public Civilian(Team team) {
+        name = 'C';
+        speed = 2;
+        health = 100;
+        rangeSight = 4;
+        rangeAttack = 2;
+        attack = 5;
+        armor = 5;
+        rangeAct = 1;
+        super.team = team;
+    }
 }

--- a/Units/FootUnit.java
+++ b/Units/FootUnit.java
@@ -1,5 +1,6 @@
 package Units;
 
 public abstract class FootUnit extends BaseUnit {
+
     int rangeAct = 1;
 }

--- a/Units/FootUnit.java
+++ b/Units/FootUnit.java
@@ -2,5 +2,5 @@ package Units;
 
 public abstract class FootUnit extends BaseUnit {
 
-  int rangeAct = 1;
+    int rangeAct = 1;
 }

--- a/Units/Tradesman.java
+++ b/Units/Tradesman.java
@@ -2,14 +2,14 @@ package Units;
 
 public class Tradesman extends FootUnit {
 
-  public Tradesman() {
-    name = 'T';
-    speed = 1;
-    health = 100;
-    rangeSight = 5;
-    rangeAttack = 1;
-    attack = 3;
-    armor = 3;
-    rangeAct = 1;
-  }
+    public Tradesman() {
+        name = 'T';
+        speed = 1;
+        health = 100;
+        rangeSight = 5;
+        rangeAttack = 1;
+        attack = 3;
+        armor = 3;
+        rangeAct = 1;
+    }
 }

--- a/Units/Tradesman.java
+++ b/Units/Tradesman.java
@@ -1,6 +1,7 @@
 package Units;
 
 public class Tradesman extends FootUnit {
+
     public Tradesman() {
         name = 'T';
         speed = 1;

--- a/View/CommandLineInterface.java
+++ b/View/CommandLineInterface.java
@@ -4,16 +4,27 @@ import Model.BaseBoard;
 import Model.Board;
 
 public class CommandLineInterface implements GameViewInterface {
-    public CommandLineInterface(){
+
+    public CommandLineInterface() {
 
     }
 
     public void displayBoard(BaseBoard board) {
         System.out.println(board);
     }
-    public void displayHelp() { System.out.println("Type \"m\" to move a unit or \"h\" for a list of commands."); }
-    public void displayInvalidCommand() { System.out.println("Invalid command! Type \"h\" for a list of commands."); }
-    public void displayCommandError(String error) { System.out.println(error);}
+
+    public void displayHelp() {
+        System.out.println("Type \"m\" to move a unit or \"h\" for a list of commands.");
+    }
+
+    public void displayInvalidCommand() {
+        System.out.println("Invalid command! Type \"h\" for a list of commands.");
+    }
+
+    public void displayCommandError(String error) {
+        System.out.println(error);
+    }
+
     public void refreshBoard(Board board) {
         displayBoard(board);
     }

--- a/View/CommandLineInterface.java
+++ b/View/CommandLineInterface.java
@@ -7,6 +7,7 @@ public class CommandLineInterface implements GameViewInterface {
     public CommandLineInterface(){
 
     }
+
     public void displayBoard(BaseBoard board) {
         System.out.println(board);
     }
@@ -14,5 +15,6 @@ public class CommandLineInterface implements GameViewInterface {
     public void displayInvalidCommand() { System.out.println("Invalid command! Type \"h\" for a list of commands."); }
     public void displayCommandError(String error) { System.out.println(error);}
     public void refreshBoard(Board board) {
-    displayBoard(board);}
+        displayBoard(board);
+    }
 }

--- a/View/GameViewInterface.java
+++ b/View/GameViewInterface.java
@@ -4,13 +4,18 @@ import Model.BaseBoard;
 import Model.Board;
 
 public interface GameViewInterface {
+
     // Method to display the current state of the board
     void displayBoard(BaseBoard board);
+
     // Method to refresh the state of the board
     void refreshBoard(Board board);
+
     // Displays help prompt
     void displayHelp();
+
     void displayInvalidCommand();
+
     void displayCommandError(String error);
 
 }

--- a/intellij-java-google-style.xml
+++ b/intellij-java-google-style.xml
@@ -2,222 +2,222 @@
 <code_scheme name="GoogleStyle">
   <option name="OTHER_INDENT_OPTIONS">
     <value>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
-      <option name="USE_TAB_CHARACTER" value="false" />
-      <option name="SMART_TABS" value="false" />
-      <option name="LABEL_INDENT_SIZE" value="0" />
-      <option name="LABEL_INDENT_ABSOLUTE" value="false" />
-      <option name="USE_RELATIVE_INDENTS" value="false" />
+      <option name="INDENT_SIZE" value="4"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="4"/>
+      <option name="USE_TAB_CHARACTER" value="false"/>
+      <option name="SMART_TABS" value="false"/>
+      <option name="LABEL_INDENT_SIZE" value="0"/>
+      <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+      <option name="USE_RELATIVE_INDENTS" value="false"/>
     </value>
   </option>
-  <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+  <option name="INSERT_INNER_CLASS_IMPORTS" value="true"/>
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999"/>
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-    <value />
+    <value/>
   </option>
   <option name="IMPORT_LAYOUT_TABLE">
     <value>
-      <package name="" withSubpackages="true" static="true" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="false" />
+      <package name="" withSubpackages="true" static="true"/>
+      <emptyLine/>
+      <package name="" withSubpackages="true" static="false"/>
     </value>
   </option>
-  <option name="RIGHT_MARGIN" value="100" />
-  <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
-  <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
-  <option name="JD_P_AT_EMPTY_LINES" value="false" />
-  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-  <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="0" />
-  <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-  <option name="ALIGN_MULTILINE_FOR" value="false" />
-  <option name="CALL_PARAMETERS_WRAP" value="1" />
-  <option name="METHOD_PARAMETERS_WRAP" value="1" />
-  <option name="EXTENDS_LIST_WRAP" value="1" />
-  <option name="THROWS_KEYWORD_WRAP" value="1" />
-  <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-  <option name="BINARY_OPERATION_WRAP" value="1" />
-  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-  <option name="TERNARY_OPERATION_WRAP" value="1" />
-  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-  <option name="FOR_STATEMENT_WRAP" value="1" />
-  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-  <option name="WRAP_COMMENTS" value="true" />
-  <option name="IF_BRACE_FORCE" value="3" />
-  <option name="DOWHILE_BRACE_FORCE" value="3" />
-  <option name="WHILE_BRACE_FORCE" value="3" />
-  <option name="FOR_BRACE_FORCE" value="3" />
-  <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+  <option name="RIGHT_MARGIN" value="100"/>
+  <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+  <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+  <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+  <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+  <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
+  <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+  <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="0"/>
+  <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+  <option name="ALIGN_MULTILINE_FOR" value="false"/>
+  <option name="CALL_PARAMETERS_WRAP" value="1"/>
+  <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+  <option name="EXTENDS_LIST_WRAP" value="1"/>
+  <option name="THROWS_KEYWORD_WRAP" value="1"/>
+  <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+  <option name="BINARY_OPERATION_WRAP" value="1"/>
+  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+  <option name="TERNARY_OPERATION_WRAP" value="1"/>
+  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+  <option name="FOR_STATEMENT_WRAP" value="1"/>
+  <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+  <option name="WRAP_COMMENTS" value="true"/>
+  <option name="IF_BRACE_FORCE" value="3"/>
+  <option name="DOWHILE_BRACE_FORCE" value="3"/>
+  <option name="WHILE_BRACE_FORCE" value="3"/>
+  <option name="FOR_BRACE_FORCE" value="3"/>
+  <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
   <AndroidXmlCodeStyleSettings>
-    <option name="USE_CUSTOM_SETTINGS" value="true" />
+    <option name="USE_CUSTOM_SETTINGS" value="true"/>
     <option name="LAYOUT_SETTINGS">
       <value>
-        <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false" />
+        <option name="INSERT_BLANK_LINE_BEFORE_TAG" value="false"/>
       </value>
     </option>
   </AndroidXmlCodeStyleSettings>
   <JSCodeStyleSettings>
-    <option name="INDENT_CHAINED_CALLS" value="false" />
+    <option name="INDENT_CHAINED_CALLS" value="false"/>
   </JSCodeStyleSettings>
   <Python>
-    <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true" />
+    <option name="USE_CONTINUATION_INDENT_FOR_ARGUMENTS" value="true"/>
   </Python>
   <TypeScriptCodeStyleSettings>
-    <option name="INDENT_CHAINED_CALLS" value="false" />
+    <option name="INDENT_CHAINED_CALLS" value="false"/>
   </TypeScriptCodeStyleSettings>
   <XML>
-    <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    <option name="XML_ALIGN_ATTRIBUTES" value="false"/>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
   </XML>
   <codeStyleSettings language="CSS">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="ECMA Script Level 4">
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <codeStyleSettings language="HTML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="WRAP_COMMENTS" value="true" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
+    <option name="THROWS_KEYWORD_WRAP" value="1"/>
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="WRAP_COMMENTS" value="true"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JSON">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JavaScript">
-    <option name="RIGHT_MARGIN" value="80" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="ALIGN_MULTILINE_FOR" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="RIGHT_MARGIN" value="80"/>
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="ALIGN_MULTILINE_FOR" value="false"/>
+    <option name="CALL_PARAMETERS_WRAP" value="1"/>
+    <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_WRAP" value="1"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="TERNARY_OPERATION_WRAP" value="1"/>
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+    <option name="IF_BRACE_FORCE" value="3"/>
+    <option name="DOWHILE_BRACE_FORCE" value="3"/>
+    <option name="WHILE_BRACE_FORCE" value="3"/>
+    <option name="FOR_BRACE_FORCE" value="3"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="PROTO">
-    <option name="RIGHT_MARGIN" value="80" />
+    <option name="RIGHT_MARGIN" value="80"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="protobuf">
-    <option name="RIGHT_MARGIN" value="80" />
+    <option name="RIGHT_MARGIN" value="80"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="Python">
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="RIGHT_MARGIN" value="80" />
-    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+    <option name="RIGHT_MARGIN" value="80"/>
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
+    <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SASS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="SCSS">
     <indentOptions>
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="TypeScript">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="XML">
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="2" />
-      <option name="TAB_SIZE" value="2" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+      <option name="TAB_SIZE" value="2"/>
     </indentOptions>
     <arrangement>
       <rules>
@@ -226,7 +226,7 @@
             <match>
               <AND>
                 <NAME>xmlns:android</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -237,7 +237,7 @@
             <match>
               <AND>
                 <NAME>xmlns:.*</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -249,7 +249,7 @@
             <match>
               <AND>
                 <NAME>.*:id</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -260,7 +260,7 @@
             <match>
               <AND>
                 <NAME>style</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -271,7 +271,7 @@
             <match>
               <AND>
                 <NAME>.*</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>^$</XML_NAMESPACE>
               </AND>
             </match>
@@ -283,7 +283,7 @@
             <match>
               <AND>
                 <NAME>.*:.*Style</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -295,7 +295,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_width</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -306,7 +306,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_height</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -317,7 +317,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_weight</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -328,7 +328,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_margin</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -339,7 +339,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginTop</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -350,7 +350,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginBottom</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -361,7 +361,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginStart</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -372,7 +372,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginEnd</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -383,7 +383,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginLeft</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -394,7 +394,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_marginRight</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -405,7 +405,7 @@
             <match>
               <AND>
                 <NAME>.*:layout_.*</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -417,7 +417,7 @@
             <match>
               <AND>
                 <NAME>.*:padding</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -428,7 +428,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingTop</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -439,7 +439,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingBottom</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -450,7 +450,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingStart</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -461,7 +461,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingEnd</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -472,7 +472,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingLeft</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -483,7 +483,7 @@
             <match>
               <AND>
                 <NAME>.*:paddingRight</NAME>
-                <XML_ATTRIBUTE />
+                <XML_ATTRIBUTE/>
                 <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
               </AND>
             </match>
@@ -537,62 +537,62 @@
     </arrangement>
   </codeStyleSettings>
   <Objective-C>
-    <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
-    <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
-    <option name="INDENT_CLASS_MEMBERS" value="2" />
-    <option name="INDENT_VISIBILITY_KEYWORDS" value="1" />
-    <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
-    <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
-    <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
-    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
-    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
-    <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
-    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
-    <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false" />
+    <option name="INDENT_NAMESPACE_MEMBERS" value="0"/>
+    <option name="INDENT_C_STRUCT_MEMBERS" value="2"/>
+    <option name="INDENT_CLASS_MEMBERS" value="2"/>
+    <option name="INDENT_VISIBILITY_KEYWORDS" value="1"/>
+    <option name="INDENT_INSIDE_CODE_BLOCK" value="2"/>
+    <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true"/>
+    <option name="FUNCTION_PARAMETERS_WRAP" value="5"/>
+    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5"/>
+    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5"/>
+    <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true"/>
+    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false"/>
+    <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false"/>
   </Objective-C>
   <Objective-C-extensions>
-    <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
-    <option name="RELEASE_STYLE" value="IVAR" />
-    <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
+    <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK"/>
+    <option name="RELEASE_STYLE" value="IVAR"/>
+    <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE"/>
     <file>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function"/>
     </file>
     <class>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod"/>
+      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod"/>
     </class>
     <extensions>
-      <pair source="cc" header="h" />
-      <pair source="c" header="h" />
+      <pair source="cc" header="h"/>
+      <pair source="c" header="h"/>
     </extensions>
   </Objective-C-extensions>
   <codeStyleSettings language="ObjectiveC">
-    <option name="RIGHT_MARGIN" value="80" />
-    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
-    <option name="BLANK_LINES_BEFORE_IMPORTS" value="0" />
-    <option name="BLANK_LINES_AFTER_IMPORTS" value="0" />
-    <option name="BLANK_LINES_AROUND_CLASS" value="0" />
-    <option name="BLANK_LINES_AROUND_METHOD" value="0" />
-    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
-    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="RIGHT_MARGIN" value="80"/>
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
+    <option name="BLANK_LINES_BEFORE_IMPORTS" value="0"/>
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="0"/>
+    <option name="BLANK_LINES_AROUND_CLASS" value="0"/>
+    <option name="BLANK_LINES_AROUND_METHOD" value="0"/>
+    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0"/>
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false"/>
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+    <option name="FOR_STATEMENT_WRAP" value="1"/>
+    <option name="ASSIGNMENT_WRAP" value="1"/>
     <indentOptions>
-      <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="INDENT_SIZE" value="2"/>
+      <option name="CONTINUATION_INDENT_SIZE" value="4"/>
     </indentOptions>
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
The **Parser**'s `getCommand` method now returns the command object with `.arguments[]` populated with the arguments the user supplied, minus the first (used to select which command) argument.

Example:

- user types `a 32 54 95`
- `Parser.getCommand` method returns an **Attack** object with `Attack.arguments = [32, 54, 95]`

All code has also been reformated to [Google Style](https://github.com/google/styleguide).