### PR TITLE
Add and implement LibGDX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>groupId</groupId>
-  <artifactId>RTS</artifactId>
+  <groupId>com.brosintime</groupId>
+  <artifactId>Convergent</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <name>RTS</name>
+  <name>Convergent</name>
   <url>https://github.com/BrosinTimeCode/RTS</url>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
   <artifactId>Convergent</artifactId>
   <version>1.0-SNAPSHOT</version>
   <name>Convergent</name>
+  <packaging>jar</packaging>
   <url>https://github.com/BrosinTimeCode/RTS</url>
 
   <build>
@@ -38,12 +39,39 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <version>2.4.1</version>
+        <executions>
+          <execution>
+            <id>make-executable-jar-with-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addClasspath>true</addClasspath>
+                  <mainClass>Main</mainClass>
+                </manifest>
+              </archive>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <gdx.version>1.9.13</gdx.version>
   </properties>
 
   <dependencies>
@@ -64,6 +92,46 @@
       <version>RELEASE</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-box2d-platform</artifactId>
+      <classifier>natives-desktop</classifier>
+      <version>${gdx.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-platform</artifactId>
+      <classifier>natives-desktop</classifier>
+      <version>${gdx.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx</artifactId>
+      <version>${gdx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-backend-lwjgl3</artifactId>
+      <version>${gdx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-box2d-platform</artifactId>
+      <version>${gdx.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.box2dlights</groupId>
+      <artifactId>box2dlights</artifactId>
+      <version>1.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-openal</artifactId>
+      <version>0.9.9</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/src/main/java/com/brosintime/rts/Main.java
+++ b/src/main/java/com/brosintime/rts/Main.java
@@ -1,12 +1,29 @@
 package com.brosintime.rts;
 
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.brosintime.rts.Controller.GameController;
+import com.brosintime.rts.View.GuiClient;
 
 public class Main {
 
     public static void main(String[] args) {
-        GameController controller = new GameController();
-        controller.run();
-        System.exit(0);
+
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setIdleFPS(60);
+        config.useVsync(true);
+        config.setTitle("Convergent");
+
+        config.setWindowedMode(1280, 720);
+
+        if (args.length != 0) {
+            if (args[0].equals("nogui")) {
+                GameController controller = new GameController();
+                controller.run();
+                System.exit(0);
+            }
+        }
+        new Lwjgl3Application(new GuiClient(), config);
+
     }
 }

--- a/src/main/java/com/brosintime/rts/View/GuiClient.java
+++ b/src/main/java/com/brosintime/rts/View/GuiClient.java
@@ -1,0 +1,11 @@
+package com.brosintime.rts.View;
+
+import com.badlogic.gdx.Game;
+
+public class GuiClient extends Game {
+
+    @Override
+    public void create() {
+
+    }
+}


### PR DESCRIPTION
This PR is to make sure LibGDX, a traditionally gradle framework, successfully works with our Maven project. [LibGDX](https://libgdx.com/) is a popular Java game framework I think could be a good foundation for our GUI.

- Rename Maven project from groupID.RTS to com.brosintime.Convergent
- Add LibGDX dependencies to our Maven project
- Add GUI as default game mode. The terminal interface can still be accessed by passing “nogui” as the first argument to Main

After checkout, download the new dependencies in IntelliJ:

![image](https://user-images.githubusercontent.com/8064810/196051889-5a0f6f71-3f3d-4d89-a72d-afd5df3eae13.png)

Then, run maven clean.